### PR TITLE
ヘッダーとフッダーの作成

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,8 @@
   </head>
 
   <body id="app">
+    <%= render 'shared/header' %>
     <%= yield %>
+    <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,10 @@
+<footer class="footer footer-center p-10 bg-base-200 text-base-content rounded">
+  <div class="grid grid-flow-col gap-4">
+    <a class="link link-hover">利用規約</a>
+    <a class="link link-hover">プライバシポリシー</a>
+    <a class="link link-hover">お問い合わせ</a>
+  </div>
+  <div>
+    <p>Copyright © 2023 - All right reserved by BESPRE</p>
+  </div>
+</footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,32 @@
+<header>
+  <div class="navbar bg-base-200">
+    <div class="flex-1">
+      <a class="btn btn-ghost normal-case text-xl">BESPRE</a>
+    </div>
+    <div class="flex-none gap-2">
+      <%# <div class="dropdown dropdown-end">
+        <label tabindex="0" class="btn btn-ghost btn-circle avatar">
+          <div class="w-10 rounded-full">
+            <img src="https://placeimg.com/80/80/people" />
+          </div>
+        </label>
+        <ul tabindex="0" class="mt-3 p-2 shadow menu menu-compact dropdown-content bg-base-100 rounded-box w-52">
+          <li>
+            <a class="justify-between">
+              Profile
+              <span class="badge">New</span>
+            </a>
+          </li>
+          <li><a>Settings</a></li>
+          <li><a>Logout</a></li>
+        </ul>
+      </div> %>
+      <div class="flex-none">
+        <ul class="menu menu-horizontal px-1">
+          <li><a>新規登録</a></li>
+          <li><a>ログイン</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</header>


### PR DESCRIPTION
## 概要
**issue** close #8

a623538 フッター追加
33f7fcd ヘッダー追加
d389800 ページにヘッダーとフッターを表示

## 確認方法
`./bin/dev` サーバ接続

## 確認結果
![642989faa894d78fdf297f655f8182da](https://user-images.githubusercontent.com/102616360/211141180-82868345-cc84-4a6b-b353-193d126cfc52.png)

## コメント
リンクはページ作成後追加。
ログイン後のヘッダーもログイン機能追加後に追加。