### PR TITLE
i18nによる日本語化対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,10 +42,15 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+# CSS/JS bundler
 gem 'cssbundling-rails'
 gem 'jsbundling-rails'
 
+# ログイン機能
 gem 'sorcery'
+
+# 日本語化対応
+gem 'rails-i18n'
 
 # Use Sass to process CSS
 # gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.6)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.4)
       actionpack (= 7.0.4)
       activesupport (= 7.0.4)
@@ -316,6 +319,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4)
+  rails-i18n
   rspec-rails
   rubocop
   rubocop-rails

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -6,8 +6,8 @@
     <div class='flex-none gap-2'>
       <div class='flex-none'>
         <ul class='menu menu-horizontal px-1'>
-          <li><%= link_to '新規登録', new_user_path, class: "" %></li>
-          <li><%= link_to 'ログイン', login_path ,class: "" %></li>
+          <li><%= link_to (t 'defaults.sign_up'), new_user_path, class: "" %></li>
+          <li><%= link_to (t 'defaults.login'), login_path ,class: "" %></li>
         </ul>
       </div>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,9 +11,9 @@
           </div>
         </label>
         <ul tabindex='0' class='menu menu-compact dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-52'>
-          <li><%= link_to 'プロフィール', '#', class: 'dropdown-item' %></li>
-          <li><%= link_to '欲しいものリスト', '#', class: 'dropdown-item' %></li>
-          <li><%= link_to 'ログアウト', logout_path, class: 'dropdown-item', method: :delete %></li>
+          <li><%= link_to (t 'defaults.profile'), '#', class: 'dropdown-item' %></li>
+          <li><%= link_to (t 'defaults.wish_lists'), '#', class: 'dropdown-item' %></li>
+          <li><%= link_to (t 'defaults.logout'), logout_path, class: 'dropdown-item', method: :delete %></li>
         </ul>
       </div>
     </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,29 +1,29 @@
 <div class="py-8">
   <div class="card w-96 bg-base-200 text-primary-content my-8 m-auto">
     <div class="text-2xl text-center font-semibold my-8">
-      <h1>ログイン</h1>
+      <h1><%= t '.title' %></h1>
     </div>
     <%= form_with url: login_path, local: true do |f| %>
       <div class="space-y-4">
         <div class="w-full max-w-xs m-auto">
           <div class="mb-2">
-            <%= f.label :email %>
+            <%= f.label :email, User.human_attribute_name(:email) %>
           </div>
           <%= f.text_field :email, class: 'input input-bordered bg-white w-full max-w-xs' %>
         </div>
         <div class="w-full max-w-xs m-auto">
           <div class="mb-2">
-            <%= f.label :password %>
+            <%= f.label :password, User.human_attribute_name(:password) %>
           </div>
           <%= f.password_field :password, class: 'input input-bordered bg-white w-full max-w-xs' %>
         </div>
         <div class="text-center">
-          <%= f.submit "ログイン", class: "btn btn-primary btn-wide text-red-100 my-6" %>
+          <%= f.submit (t 'defaults.login'), class: "btn btn-primary btn-wide text-red-100 my-6" %>
         </div>
       </div>
     <% end %>
     <div class= "text-center pb-8">
-          <%= link_to "新規登録の方はこちら", new_user_path, class: "link link-hover" %>
-        </div>
+      <%= link_to (t '.to_register_page'), new_user_path, class: "link link-hover" %>
+    </div>
   </div>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <div class="py-8">
   <div class="card w-96 bg-base-200 text-primary-content my-8 m-auto">
     <div class="text-2xl text-center font-semibold my-8">
-      <h1>新規登録</h1>
+      <h1><%= t '.title' %></h1>
     </div>
     <%= form_with model: @user, local: true do |f| %>
       <div class="space-y-4">
@@ -30,12 +30,12 @@
           <%= f.password_field :password_confirmation, class: 'input input-bordered bg-white w-full max-w-xs' %>
         </div>
         <div class="text-center">
-          <%= f.submit '登録', class: 'btn btn-primary btn-wide text-red-100 my-8' %>
+          <%= f.submit (t 'defaults.register'), class: 'btn btn-primary btn-wide text-red-100 my-8' %>
         </div>
       </div>
     <% end %>
     <div class='text-center pb-8'>
-      <%= link_to 'ログインページへ', login_path, class: "link link-hover" %>
+      <%= link_to (t '.to_login_page'), login_path, class: "link link-hover" %>
     </div>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,8 @@ module BestPresent
       g.assets false
       g.helper false
     end
+
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:
+    models:
+      user: 'ユーザー'
+    attributes:
+      user:
+        email: 'メールアドレス'
+        password: 'パスワード'
+        password_confirmation: 'パスワード確認'
+        name: '名前'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,20 @@
+ja:
+  defaults:
+    login: 'ログイン'
+    logout: 'ログアウト'
+    sign_up: '新規登録'
+    register: '登録'
+    profile: 'プロフィール'
+    wish_lists: '欲しいものリスト'
+  users:
+    new:
+      title: '新規登録'
+      to_login_page: 'ログインページへ'
+  user_sessions:
+    new:
+      title: 'ログイン'
+      to_register_page: '新規登録の方はこちら'
+      password_forget: 'パスワードをお忘れの方はこちら'
+  profiles:
+    show:
+      title: 'プロフィール'


### PR DESCRIPTION
## 概要
**issue** close #42

df8fa05 `gem rails-i8n`を`bundle install`。
b80c17a `./config/application.rb`に日本語化設定を記載。
6d4ec09 `ja.yml`に記述された翻訳を読み込むようにヘッダーを修正。
6fe3d90 `ja.yml`に記述された翻訳を読み込むように新規登録/ログイン画面を修正。

## 確認方法
` ./bin/dev`で確認。

<img width="1410" alt="58cf72e1df53aa1fad5c355b46334cf6" src="https://user-images.githubusercontent.com/102616360/212550299-982fbd90-8355-47be-bb3a-f5dc23f7a909.png">
<img width="1409" alt="6d3df083dbe96c5e922612d6fa7ce027" src="https://user-images.githubusercontent.com/102616360/212550304-ef6aaa6f-5013-4bbd-974f-870e660ebd4a.png">
