### PR TITLE
Flash messagesを設定

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,1 @@
+//= require rails-ujs

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :success, :info, :warning, :danger
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,14 +4,15 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to root_path
+      redirect_back_or_to root_path, success: t('.success')
     else
+      flash.now[:danger] = t('.fail')
       render :new
     end
   end
 
   def destroy
     logout
-    redirect_to root_path
+    redirect_to root_path, success: t('.success')
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,8 +6,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to login_path
+      redirect_to login_path, success: t('.success')
     else
+      flash.now[:danger] = t('.fail')
       render :new
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
+    <%= render 'shared/flash_message' %>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,3 @@
+<% flash.each do |message_type, message| %>
+  <div class="alert alert-<%= message_type %>"><%= message %></div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -15,13 +15,13 @@
           <div class="mb-2">
             <%= f.label :email %>
           </div>
-          <%= f.email_field :lemail, class: 'input input-bordered bg-white w-full max-w-xs' %>
+          <%= f.email_field :email, class: 'input input-bordered bg-white w-full max-w-xs' %>
         </div>
         <div class="w-full max-w-xs m-auto">
           <div class="mb-2">
             <%= f.label :password %>
           </div>
-          <%= f.password_field :lpassword, class: 'input input-bordered bg-white w-full max-w-xs' %>
+          <%= f.password_field :password, class: 'input input-bordered bg-white w-full max-w-xs' %>
         </div>
         <div class="w-full max-w-xs m-auto">
           <div class="mb-2">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -10,11 +10,19 @@ ja:
     new:
       title: '新規登録'
       to_login_page: 'ログインページへ'
+    create:
+      success: 'ユーザー登録が完了しました'
+      fail: 'ユーザー登録に失敗しました'
   user_sessions:
     new:
       title: 'ログイン'
       to_register_page: '新規登録の方はこちら'
       password_forget: 'パスワードをお忘れの方はこちら'
+    create:
+      success: 'ログインしました'
+      fail: 'ログインに失敗しました'
+    destroy:
+      success: 'ログアウトしました'
   profiles:
     show:
       title: 'プロフィール'


### PR DESCRIPTION
## 概要
**issue** close #44

ba67b2d [ f7eef29 ]でタイポがあったため修正。
4c90c71 フラッシュメッセージを定義。
c980a18 ログイン、ログアウト時にフラッシュメッセージを表示できるように実装。
622dc8a ユーザー作成時にフラッシュメッセージを表示できるように実装。
a99de65 フラッシュメッセージの表示をViewに追加。
db6e006 フラッシュメッセージの翻訳定義を追加。
cf5c7de ログアウト時に`No route matches [GET] "/logout"`のエラーが起きてしまうため、rails-ujsをマニフェストファイルのapplication.jsに追加してログアウトできるように修正。

## 確認方法
`./bin/dev`で確認。

<img width="201" alt="5b426c65330d15c27cb1f5e085cb254b" src="https://user-images.githubusercontent.com/102616360/212730984-72ee1ca5-299e-4c3c-8809-71d2198e6494.png">
<img width="241" alt="5ee7974508fc627d1fa194ff0800f27e" src="https://user-images.githubusercontent.com/102616360/212730999-1ce91e27-d438-48ec-9d72-eecd3f5202d3.png">
<img width="182" alt="3ef60d1244a7eb3161f12148bfd159b2" src="https://user-images.githubusercontent.com/102616360/212731014-41363d60-e84d-446e-bcb4-f083d42207bd.png">
<img width="187" alt="df173d2ecff14911d17c1d131e0e4124" src="https://user-images.githubusercontent.com/102616360/212731021-a9bcdee1-7d06-43ed-bf59-aa18af6454ba.png">

## コメント
【 cf5c7de の修正の原因】
HTML上のルールとして、aタグはGETメソッドになるが、
rails-ujsというJavascriptが機能することで、deleteやpostとしてリクエストができるようになっている。
マニフェストファイルに`//= require rails-ujs`を記載することで`data-method="delete"`がうまく作動する。

### 参考文献
https://kentarotawara.hatenablog.com/entry/2020/06/24/172509
https://www.inodev.jp/entry/2019/12/03/234210