### PR TITLE
欲しいものリスト作成画面追加

### DIFF
--- a/app/controllers/wish_lists_controller.rb
+++ b/app/controllers/wish_lists_controller.rb
@@ -3,11 +3,31 @@ class WishListsController < ApplicationController
     @wish_lists = WishList.all.includes(:user).order(created_at: :desc)
   end
 
-  def show
+  def new
+    @wish_list = WishList.new
+  end
 
+  def create
+    @wish_list = current_user.wish_lists.build(wish_list_params)
+    if @wish_list.save
+      redirect_to wish_lists_path, success: t('defaults.message.created', item: WishList.model_name.human)
+    else
+      flash.now['danger'] = t('defaults.message.not_created', item: WishList.model_name.human)
+      render :new
+    end
+  end
+
+  def show
+    @wish_list = WishList.find(params[:id])
   end
 
   def edit
 
+  end
+
+  private
+
+  def wish_list_params
+    params.require(:wish_list).permit(:list_name)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,4 @@
+class Item < ApplicationRecord
+  has_many :wish_lists, through: :wish_list_items
+  has_many :wish_list_items
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
   mount_uploader :avatar, AvatarUploader
 
-  has_many :wish_list, dependent: :destroy
+  has_many :wish_lists, dependent: :destroy
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/wish_list.rb
+++ b/app/models/wish_list.rb
@@ -1,5 +1,7 @@
 class WishList < ApplicationRecord
   belongs_to :user
+  has_many :items, through: :wish_list_items
+  has_many :wish_list_items
 
   validates :list_name, presence: true, length: { maximum: 255 }
 end

--- a/app/models/wish_list.rb
+++ b/app/models/wish_list.rb
@@ -1,5 +1,5 @@
 class WishList < ApplicationRecord
-  belongs_to :User
+  belongs_to :user
 
-  validates :name, presence: true, length: { maximum: 255 }
+  validates :list_name, presence: true, length: { maximum: 255 }
 end

--- a/app/models/wish_list_item.rb
+++ b/app/models/wish_list_item.rb
@@ -1,0 +1,4 @@
+class WishListItem < ApplicationRecord
+  belongs_to :wish_list
+  belongs_to :item
+end

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,6 +1,7 @@
 <% if object.errors.any? %>
-  <div id="error_messages" class="alert alert-danger">
-    <ul class="mb-0">
+  <div class="alert alert-error shadow-lg">
+    <ul>
+      <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
       <% object.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>
       <% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,3 +1,11 @@
 <% flash.each do |message_type, message| %>
-  <div class="alert alert-<%= message_type %>"><%= message %></div>
+  <% if message_type == 'success' %>
+    <div class="alert alert-success shadow-lg"><%= message %></div>
+  <% elsif message_type == 'danger' %>
+    <div class="alert alert-error shadow-lg"><%= message %></div>
+  <% elsif message_type == 'warning' %>
+    <div class="alert alert-warning shadow-lg"><%= message %></div>
+  <% else %>
+    <div class="alert shadow-lg"><%= message %></div>
+  <% end %>
 <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,9 +11,9 @@
           </div>
         </label>
         <ul tabindex='0' class='menu menu-compact dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-52'>
-          <li><%= link_to (t 'defaults.mypages'), mypage_path, class: 'dropdown-item' %></li>
-          <li><%= link_to (t 'defaults.wish_lists'), wish_lists_path, class: 'dropdown-item' %></li>
-          <li><%= button_to (t 'defaults.logout'), logout_path, class: 'dropdown-item', method: :delete %></li>
+          <li><%= link_to (t 'defaults.mypages'), mypage_path %></li>
+          <li><%= link_to (t 'defaults.wish_lists'), wish_lists_path %></li>
+          <li><%= button_to (t 'defaults.logout'), logout_path, method: :delete %></li>
         </ul>
       </div>
     </div>

--- a/app/views/wish_lists/_form.html.erb
+++ b/app/views/wish_lists/_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_with model: wish_list, local: true do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class="space-y-4 mt-5">
+    <div class="w-full max-w-xs m-auto">
+      <%= f.text_field :list_name, placeholder: (t 'defaults.list_name'), class: 'input input-bordered bg-white w-full max-w-xs' %>
+    </div>
+    <div class="text-center">
+      <%= f.submit (t 'defaults.create'), class: 'btn btn-primary btn-wide text-red-100 my-8' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/wish_lists/_wish_list.html.erb
+++ b/app/views/wish_lists/_wish_list.html.erb
@@ -3,6 +3,6 @@
     <%= image_tag "present_box.png", class: "rounded-xl", size: "150x150" %>
   </figure>
   <div class="card-body items-center text-center pt-5">
-    <h2 class="card-title"><%= link_to @wish_lists.name, '#' %></h2>
+    <h2 class="card-title"><%= link_to wish_list.list_name, '#' %></h2>
   </div>
 </div>

--- a/app/views/wish_lists/index.html.erb
+++ b/app/views/wish_lists/index.html.erb
@@ -1,17 +1,20 @@
-<div class="container pt-3">
-  <div class="row">
-    <div class="col-lg-10 offset-lg-1">
-      <!-- 検索フォーム -->
-      <div class="form-control">
-        <div class="input-group">
-          <input type="text" placeholder="Search…" class="input input-bordered" />
-          <button class="btn btn-square">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" height="24px" viewBox="0 0 24 24" width="24px" fill="#FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
-          </button>
-        </div>
+<div class="pt-3 my-16">
+  <div class="mb-16 text-3xl text-center font-semibold">
+    <h1><%= t('.title') %></h1>
+  </div>
+  <!-- 検索フォーム -->
+  <div class="form-control">
+    <div class="input-group m-auto">
+      <input type="text" placeholder="Search…" class="input input-bordered" />
+      <button class="btn btn-square">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" height="24px" viewBox="0 0 24 24" width="24px" fill="#FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+      </button>
+      <div class="rounded-lg ml-10">
+        <%= link_to t('.create'), new_wish_list_path, class: "btn btn-primary btn-wide text-red-100" %>
       </div>
     </div>
   </div>
+
 
   <!-- 欲しいものリスト一覧 -->
   <div class="flex">

--- a/app/views/wish_lists/new.html.erb
+++ b/app/views/wish_lists/new.html.erb
@@ -1,0 +1,6 @@
+<div class="pt-3 my-16 w-96 text-primary-content m-auto">
+  <div class="mb-14 text-3xl text-center font-semibold">
+    <h1><%= t('.title') %></h1>
+  </div>
+  <%= render 'form', { wish_list: @wish_list } %>
+</div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     models:
       user: 'ユーザー'
+      wish_list: '欲しいものリスト'
     attributes:
       user:
         email: 'メールアドレス'
@@ -9,3 +10,5 @@ ja:
         password_confirmation: 'パスワード確認'
         name: '名前'
         avatar: 'アイコン'
+      wish_list:
+        list_name: 'リスト名'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,8 @@ ja:
     mypages: 'マイページ'
     wish_lists: '欲しいものリスト'
     edit: 'プロフィール編集'
+    list_name: 'リスト名'
+    create: 'リスト作成'
     message:
       require_login: 'ログインしてください'
       created: "%{item}を作成しました"
@@ -40,4 +42,8 @@ ja:
       title: 'プロフィール編集'
   wish_lists:
     index:
+      title: '欲しいものリスト一覧'
       no_result: '欲しいものリストがありません。'
+      create: 'リスト作成'
+    new:
+      title: '欲しいものリスト作成'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[new create]
   resource :mypage, only: %i[show edit update]
-  resources :wish_lists, only: %i[index]
+  resources :wish_lists, only: %i[index new create]
 end

--- a/db/migrate/20230125143520_create_wish_lists.rb
+++ b/db/migrate/20230125143520_create_wish_lists.rb
@@ -1,7 +1,7 @@
 class CreateWishLists < ActiveRecord::Migration[7.0]
   def change
     create_table :wish_lists do |t|
-      t.string :name, null: false
+      t.string :list_name, null: false
       t.references :user, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20230127122631_create_items.rb
+++ b/db/migrate/20230127122631_create_items.rb
@@ -1,0 +1,12 @@
+class CreateItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :items do |t|
+      t.string :item_name, null: false
+      t.integer :price, null: false
+      t.string :image
+      t.string :url, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230127123118_create_wish_list_items.rb
+++ b/db/migrate/20230127123118_create_wish_list_items.rb
@@ -1,0 +1,10 @@
+class CreateWishListItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :wish_list_items do |t|
+      t.references :wish_list, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_25_143520) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_27_123118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "items", force: :cascade do |t|
+    t.string "item_name", null: false
+    t.integer "price", null: false
+    t.string "image"
+    t.string "url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
@@ -25,6 +34,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_143520) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  create_table "wish_list_items", force: :cascade do |t|
+    t.bigint "wish_list_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_wish_list_items_on_item_id"
+    t.index ["wish_list_id"], name: "index_wish_list_items_on_wish_list_id"
+  end
+
   create_table "wish_lists", force: :cascade do |t|
     t.string "list_name", null: false
     t.bigint "user_id"
@@ -33,5 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_143520) do
     t.index ["user_id"], name: "index_wish_lists_on_user_id"
   end
 
+  add_foreign_key "wish_list_items", "items"
+  add_foreign_key "wish_list_items", "wish_lists"
   add_foreign_key "wish_lists", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,7 +26,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_143520) do
   end
 
   create_table "wish_lists", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "list_name", null: false
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## 概要
**issue** close #19

d7e450d `wish_lists`テーブルの`name`カラムを`list_name`カラムに変更。
7ef7d4a タイポ修正。`User`→`user`、`wish_list`→`wish_lists`。
b1eec39 フラッシュメッセージがタイプごとに変化するように変更。
6854944 クラス削除。
011308a route追加。
6fb4971 リスト作成のコントローラーを実装。
a98990a リスト一覧ページ修正。
a2b0878 リスト作成画面を実装。
01af1cc 日本語定義追加。
93b1f5f エラーメッセージにクラス追加。アイコン追加。
8070efd itemsテーブルとwish_list_itemsテーブルの追加（中間テーブル）
9c4b2a8 wish_listモデルとitemモデルのアソシエーション
