### PR TITLE
楽天商品検索API導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem 'rails-i18n'
 gem 'carrierwave'
 gem 'mini_magick'
 
+# 楽天商品検索API
+gem 'rakuten_web_service'
+
 # Use Sass to process CSS
 # gem "sassc-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,6 +220,8 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    rakuten_web_service (1.13.1)
+      json (~> 2.3)
     regexp_parser (2.6.1)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -334,6 +336,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.4)
   rails-i18n
+  rakuten_web_service
   rspec-rails
   rubocop
   rubocop-rails

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,0 +1,7 @@
+class ItemsController < ApplicationController
+  def search
+    if params[:keyword]
+      @items = RakutenWebService::Ichiba::Item.search(keyword: params[:keyword])
+    end
+  end
+end

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,0 +1,7 @@
+<% @items.first(10).each do |item| %>
+  <div class="list-group">
+    <%= image_tag (item['smallImageUrls'][0]) %>
+    <%= link_to item.name, "#{item.url}" %>
+    <%= number_with_delimiter(item.price) %>円
+  </div>
+<% end %>

--- a/app/views/items/search.html.erb
+++ b/app/views/items/search.html.erb
@@ -1,0 +1,12 @@
+<h1>製品名を入力して検索</h1>
+<div class="search-box">
+  <%= form_with url: items_search_path, method: :get, local: true do |f| %>
+    <div class="form-group">
+        <%= f.text_field :keyword, value: params[:keyword], class: "form-control" %>
+        <%= f.submit '製品名を検索', class: "form-control btn btn-success" %>
+    </div>
+  <% end %>
+  <% if @items.present? %>
+    <%= render 'items/item' %>
+  <% end %>
+</div>

--- a/config/initializers/rakuten.rb
+++ b/config/initializers/rakuten.rb
@@ -1,0 +1,8 @@
+RakutenWebService.configure do |c|
+  # (必須) アプリケーションID
+  c.application_id = '1099764983145187245'
+
+  # (任意) 楽天アフィリエイトID
+  c.affiliate_id = '2f5342f6.0b26c79c.2f5342f7.f5f25cb3'
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'items/search'
   root 'static_pages#top'
 
   get 'login', to: 'user_sessions#new'


### PR DESCRIPTION
## 概要
**issue** close #62

a91518a `gem 'rakuten_web_service'`を追加後` bundle install`。
cb066f1 楽天市場から商品検索できるようにコントロールに設定。
a7a2ad2 商品検索のページ追加。
bfcfd4c ルート追加。
80fd135 取得したアプリケーションIDと楽天アフィリエイトを。

## 確認方法
`bin/dev`確認

![933a825093e4b47412ef1890a7d62006](https://user-images.githubusercontent.com/102616360/215783925-9de30722-eee4-4157-a23e-1c15455f2d4a.png)

## コメント
Amazonの商品検索できるAPIを導入予定だったが、ある程度の実績がないと導入できないとのこと。