### PR TITLE
商品検索ページとページネーションの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ gem 'mini_magick'
 # 楽天商品検索API
 gem 'rakuten_web_service'
 
+# ページネーション
+gem 'kaminari'
+
 # Use Sass to process CSS
 # gem "sassc-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,18 @@ GEM
       railties (>= 6.0.0)
     json (2.6.3)
     jwt (2.6.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -331,6 +343,7 @@ DEPENDENCIES
   factory_bot_rails
   jbuilder
   jsbundling-rails
+  kaminari
   mini_magick
   pg (~> 1.1)
   puma (~> 5.0)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,12 @@
 class ItemsController < ApplicationController
   def search
     if params[:keyword]
-      @items = RakutenWebService::Ichiba::Item.search(keyword: params[:keyword])
+      items = RakutenWebService::Ichiba::Item.search(keyword: params[:keyword])
+      @items_full = []
+      items.each do |item|
+        @items_full.push(item)
+      end
+      @items = Kaminari.paginate_array(@items_full).page(params[:page])
     end
   end
 end

--- a/app/controllers/wish_lists_controller.rb
+++ b/app/controllers/wish_lists_controller.rb
@@ -1,6 +1,6 @@
 class WishListsController < ApplicationController
   def index
-    @wish_lists = WishList.all.includes(:user).order(created_at: :desc)
+    @wish_lists = WishList.all.includes(:user).order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,7 +1,9 @@
-<% @items.first(10).each do |item| %>
-  <div class="list-group">
-    <%= image_tag (item['smallImageUrls'][0]) %>
-    <%= link_to item.name, "#{item.url}" %>
-    <%= number_with_delimiter(item.price) %>円
+<% @items.each do |item| %>
+  <div class="card card-compact w-60 bg-base-200 shadow-xl m-8">
+    <%= image_tag (item['mediumImageUrls'][0]) %>
+    <div class="card-body">
+      <h2 class="card-title"><%= link_to item.name, "#{item.url}", target: :_blank, rel: "noopener noreferrer" %></h2>
+      <p><%= number_with_delimiter(item.price) %>円</p>
+    </div>
   </div>
 <% end %>

--- a/app/views/items/search.html.erb
+++ b/app/views/items/search.html.erb
@@ -1,12 +1,21 @@
-<h1>製品名を入力して検索</h1>
-<div class="search-box">
-  <%= form_with url: items_search_path, method: :get, local: true do |f| %>
-    <div class="form-group">
-        <%= f.text_field :keyword, value: params[:keyword], class: "form-control" %>
-        <%= f.submit '製品名を検索', class: "form-control btn btn-success" %>
+<div class="pt-3 my-16 text-primary-content m-auto">
+  <div class="mb-14 text-3xl text-center font-semibold">
+    <h1>商品を検索</h1>
+  </div>
+  <div class="form-control">
+    <%= form_with url: items_search_path, method: :get, local: true do |f| %>
+      <div class="input-group justify-center">
+          <%= f.text_field :keyword, value: params[:keyword], class: "input input-bordered text-center" %>
+          <%= f.submit '検索', class: "btn btn-square" %>
+      </div>
+    <% end %>
+    <div class="flex flex-wrap justify-evenly mx-20">
+      <% if @items.present? %>
+        <%= render 'items/item' %>
+      <% end %>
     </div>
-  <% end %>
+  </div>
   <% if @items.present? %>
-    <%= render 'items/item' %>
+    <%= paginate @items %>
   <% end %>
 </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first btn">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap btn btn-disabled"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last btn">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next btn">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page btn<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,27 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <div class="text-center mt-20">
+    <nav class="pagination btn-group" role="navigation" aria-label="pager">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.display_tag? -%>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end -%>
+      <% end -%>
+      <% unless current_page.out_of_range? %>
+        <%= next_page_tag unless current_page.last? %>
+        <%= last_page_tag unless current_page.last? %>
+      <% end %>
+    </nav>
+  </div>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev btn">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+</span>

--- a/app/views/wish_lists/_wish_list.html.erb
+++ b/app/views/wish_lists/_wish_list.html.erb
@@ -1,4 +1,4 @@
-<div class="card w-60 bg-base-200 shadow-xl">
+<div class="card w-60 bg-base-200 shadow-xl m-8">
   <figure class="px-10 pt-2">
     <%= image_tag "present_box.png", class: "rounded-xl", size: "150x150" %>
   </figure>

--- a/app/views/wish_lists/index.html.erb
+++ b/app/views/wish_lists/index.html.erb
@@ -3,13 +3,15 @@
     <h1><%= t('.title') %></h1>
   </div>
   <!-- 検索フォーム -->
-  <div class="form-control">
-    <div class="input-group m-auto">
-      <input type="text" placeholder="Search…" class="input input-bordered" />
-      <button class="btn btn-square">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" height="24px" viewBox="0 0 24 24" width="24px" fill="#FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
-      </button>
-      <div class="rounded-lg ml-10">
+  <div class="form-control mx-40">
+    <div class="input-group justify-evenly mb-10 flex-wrap">
+      <div class="flex items-start">
+        <input type="text" placeholder="Search…" class="input input-bordered mb-4 w-80" />
+        <button class="btn btn-square">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" height="24px" viewBox="0 0 24 24" width="24px" fill="#FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+        </button>
+      </div>
+      <div class="rounded-lg">
         <%= link_to t('.create'), new_wish_list_path, class: "btn btn-primary btn-wide text-red-100" %>
       </div>
     </div>
@@ -17,11 +19,12 @@
 
 
   <!-- 欲しいものリスト一覧 -->
-  <div class="flex">
+  <div class="flex flex-wrap justify-evenly mx-20">
     <% if @wish_lists.present? %>
       <%= render @wish_lists %>
     <% else %>
       <p><%= t('.no_result') %></p>
     <% end %>
   </div>
+  <%= paginate @wish_lists %>
 </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 8
+  # config.max_per_page = nil
+  config.window = 3
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -8,7 +8,7 @@ Kaminari.configure do |config|
   # config.left = 0
   # config.right = 0
   # config.page_method_name = :page
-  config.param_name = :page
+  # config.param_name = :page
   # config.max_pages = nil
   # config.params_on_first_page = false
 end

--- a/config/locales/kaminari/ja.yml
+++ b/config/locales/kaminari/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."


### PR DESCRIPTION
## 概要
**issue** close #64 , close #65

04fd751 `kaminari`導入。設定ファイル作成。
9c5293b `bin/rails g kaminari:views default` でページネーションのデフォルト作成・編集。
8bb4f83 欲しいものリスト一覧の取得処理実装。
f4d929d 欲しいものリスト一覧ページにページネーション表示。
5cb6d47 `kaminari`の日本語設定。
80dc1e2 `kaminari`の設定変更。
dc316c4 商品検索ページにページネーションが適用されるように実装。
026d966 商品検索ページを修正。

## コメント
楽天商品検索が1度に30件までしかデータが取り出せない。
取り出す方法を模索中。
