### PR TITLE
利用規約とプライバシーポリシーはログイン前でも閲覧できるように実装

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,9 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :require_login, only: %i[top]
+  skip_before_action :require_login
 
   def top; end
+
+  def privacy_policy; end
+
+  def terms_of_service; end
 end


### PR DESCRIPTION
## 概要
`skip_before_action :require_login` で全体で設定していた`before_action :require_login`をスキップ。
TOPページと利用規約とプライバシーポリシーはログイン前でも閲覧できるように修正。
