### PR TITLE
バリデーション失敗時にエラーメッセージが表示されるようにする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  add_flash_types :success, :info, :warning, :danger
+  add_flash_types :success, :error
   before_action :require_login
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,7 +10,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to wish_list_path(@wish_list), success: t('defaults.message.add', item: Item.model_name.human)
     else
-      flash.now['danger'] = t('defaults.message.not_add', item: Item.model_name.human)
+      flash.now[:danger] = t('defaults.message.not_add', item: Item.model_name.human)
       render :new
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,7 +11,7 @@ class ItemsController < ApplicationController
       redirect_to wish_list_path(@wish_list), success: t('defaults.message.add', item: Item.model_name.human)
     else
       flash.now[:danger] = t('defaults.message.not_add', item: Item.model_name.human)
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,7 +10,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to wish_list_path(@wish_list), success: t('defaults.message.add', item: Item.model_name.human)
     else
-      flash.now[:danger] = t('defaults.message.not_add', item: Item.model_name.human)
+      flash.now[:error] = t('defaults.message.not_add', item: Item.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -14,7 +14,7 @@ class MessagesController < ApplicationController
       redirect_to mypage_path, success: t('defaults.message.created', item: Message.model_name.human)
     else
       flash.now[:danger] = t('defaults.message.not_created', item: Message.model_name.human)
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -13,7 +13,7 @@ class MessagesController < ApplicationController
       @message.update!(message_image: image)
       redirect_to mypage_path, success: t('defaults.message.created', item: Message.model_name.human)
     else
-      flash.now[:danger] = t('defaults.message.not_created', item: Message.model_name.human)
+      flash.now[:error] = t('defaults.message.not_created', item: Message.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -13,7 +13,7 @@ class MessagesController < ApplicationController
       @message.update!(message_image: image)
       redirect_to mypage_path, success: t('defaults.message.created', item: Message.model_name.human)
     else
-      flash.now['danger'] = t('defaults.message.not_created', item: Message.model_name.human)
+      flash.now[:danger] = t('defaults.message.not_created', item: Message.model_name.human)
       render :new
     end
   end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -11,7 +11,7 @@ class MypagesController < ApplicationController
     if @user.update(user_params)
       redirect_to mypage_path, success: t('defaults.message.updated', item: User.model_name.human)
     else
-      flash[:danger] = t('defaults.message.not_updated', item: User.model_name.human)
+      flash[:error] = t('defaults.message.not_updated', item: User.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -12,7 +12,7 @@ class MypagesController < ApplicationController
       redirect_to mypage_path, success: t('defaults.message.updated', item: User.model_name.human)
     else
       flash[:danger] = t('defaults.message.not_updated', item: User.model_name.human)
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -11,7 +11,7 @@ class MypagesController < ApplicationController
     if @user.update(user_params)
       redirect_to mypage_path, success: t('defaults.message.updated', item: User.model_name.human)
     else
-      flash.now['danger'] = t('defaults.message.not_updated', item: User.model_name.human)
+      flash[:danger] = t('defaults.message.not_updated', item: User.model_name.human)
       render :edit
     end
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -9,7 +9,7 @@ class UserSessionsController < ApplicationController
       redirect_back_or_to root_path, success: t('.success')
     else
       flash.now[:danger] = t('.fail')
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -8,7 +8,7 @@ class UserSessionsController < ApplicationController
     if @user
       redirect_back_or_to root_path, success: t('.success')
     else
-      flash.now[:danger] = t('.fail')
+      flash.now[:error] = t('.fail')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
       redirect_to login_path, success: t('.success')
     else
       flash.now[:danger] = t('.fail')
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
     if @user.save
       redirect_to login_path, success: t('.success')
     else
-      flash.now[:danger] = t('.fail')
+      flash.now[:error] = t('.fail')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/wish_lists_controller.rb
+++ b/app/controllers/wish_lists_controller.rb
@@ -22,7 +22,7 @@ class WishListsController < ApplicationController
       redirect_to wish_list_path(@wish_list), success: t('defaults.message.created', item: WishList.model_name.human)
     else
       flash.now[:danger] = t('defaults.message.not_created', item: WishList.model_name.human)
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -30,7 +30,8 @@ class WishListsController < ApplicationController
     if @wish_list.update(wish_list_params)
       redirect_to @wish_list, success: t('defaults.message.updated', item: WishList.model_name.human)
     else
-      render :edit
+      flash.now[:danger] = t('defaults.message.not_updated', item: WishList.model_name.human)
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/wish_lists_controller.rb
+++ b/app/controllers/wish_lists_controller.rb
@@ -21,7 +21,7 @@ class WishListsController < ApplicationController
     if @wish_list.save
       redirect_to wish_list_path(@wish_list), success: t('defaults.message.created', item: WishList.model_name.human)
     else
-      flash.now['danger'] = t('defaults.message.not_created', item: WishList.model_name.human)
+      flash.now[:danger] = t('defaults.message.not_created', item: WishList.model_name.human)
       render :new
     end
   end

--- a/app/controllers/wish_lists_controller.rb
+++ b/app/controllers/wish_lists_controller.rb
@@ -21,7 +21,7 @@ class WishListsController < ApplicationController
     if @wish_list.save
       redirect_to wish_list_path(@wish_list), success: t('defaults.message.created', item: WishList.model_name.human)
     else
-      flash.now[:danger] = t('defaults.message.not_created', item: WishList.model_name.human)
+      flash.now[:error] = t('defaults.message.not_created', item: WishList.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -30,7 +30,7 @@ class WishListsController < ApplicationController
     if @wish_list.update(wish_list_params)
       redirect_to @wish_list, success: t('defaults.message.updated', item: WishList.model_name.human)
     else
-      flash.now[:danger] = t('defaults.message.not_updated', item: WishList.model_name.human)
+      flash.now[:error] = t('defaults.message.not_updated', item: WishList.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/models/wish_list.rb
+++ b/app/models/wish_list.rb
@@ -7,5 +7,5 @@ class WishList < ApplicationRecord
     ["created_at", "id", "list_name", "updated_at", "user_id"]
   end
 
-  validates :list_name, presence: true, length: { maximum: 255 }
+  validates :list_name, presence: true, length: { in: 1..75 }
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,11 +24,13 @@
       <%= render 'shared/header' %>
       <%= render 'shared/flash_message' %>
       <%= yield %>
-      <% if logged_in? %>
-        <%= render 'shared/bottom_navbar' %>
-      <% else %>
-        <%= render 'shared/before_login_bottom_navbar' %>
-      <% end %>
+      <div class="font-sawarabi">
+        <% if logged_in? %>
+          <%= render 'shared/bottom_navbar' %>
+        <% else %>
+          <%= render 'shared/before_login_bottom_navbar' %>
+        <% end %>
+      </div>
     </div>
   </body>
 </html>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,7 +1,6 @@
 <% if object.errors.any? %>
   <div class="alert alert-error shadow-lg">
-    <ul>
-      <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+    <ul class="block">
       <% object.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>
       <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,6 +1,6 @@
 <% if object.errors.any? %>
-  <div class="alert alert-error shadow-lg">
-    <ul class="block">
+  <div class="alert alert-error shadow-lg w-80 m-auto mb-4 px-10">
+    <ul class="block list-disc">
       <% object.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>
       <% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,10 +1,8 @@
 <% flash.each do |message_type, message| %>
   <% if message_type == 'success' %>
     <div class="alert alert-success shadow-lg"><%= message %></div>
-  <% elsif message_type == 'danger' %>
+  <% elsif message_type == 'error' %>
     <div class="alert alert-error shadow-lg"><%= message %></div>
-  <% elsif message_type == 'warning' %>
-    <div class="alert alert-warning shadow-lg"><%= message %></div>
   <% else %>
     <div class="alert shadow-lg"><%= message %></div>
   <% end %>

--- a/app/views/wish_lists/_crud_menus.html.erb
+++ b/app/views/wish_lists/_crud_menus.html.erb
@@ -1,4 +1,4 @@
 <div class="text-center mb-4">
   <%= link_to t('defaults.list.edit'), edit_wish_list_path(wish_list), class: "btn btn-secondary mb-4 w-40" %>
-  <%= button_to t('defaults.list.delete'), wish_list_path(wish_list), class: "btn btn-accent w-40", method: :delete %>
+  <%= button_to t('defaults.list.delete'), wish_list_path(wish_list), class: "btn btn-accent w-40", method: :delete, data: { turbo_confirm: t('defaults.message.delete_confirm') } %>
 </div>

--- a/app/views/wish_lists/_form.html.erb
+++ b/app/views/wish_lists/_form.html.erb
@@ -4,7 +4,9 @@
       <%= image_tag "present_box.png", class: "rounded-xl", size: "150x150" %>
     </figure>
     <%= form_with model: wish_list do |f| %>
-      <%= render 'shared/error_messages', object: f.object %>
+      <div class="flex">
+        <%= render 'shared/error_messages', object: f.object %>
+      </div>
       <div class="card-body link link-hover pt-2">
         <%= f.text_field :list_name, placeholder: t('defaults.list.name'), class: 'card-title input input-bordered text-center bg-white w-full max-w-xs' %>
       </div>

--- a/app/views/wish_lists/_form.html.erb
+++ b/app/views/wish_lists/_form.html.erb
@@ -6,11 +6,11 @@
     <%= form_with model: wish_list do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
       <div class="card-body link link-hover pt-2">
-        <%= f.text_field :list_name, placeholder: (t 'defaults.list.name'), class: 'card-title input input-bordered text-center bg-white w-full max-w-xs' %>
+        <%= f.text_field :list_name, placeholder: t('defaults.list.name'), class: 'card-title input input-bordered text-center bg-white w-full max-w-xs' %>
       </div>
       <div class="text-center mb-4">
-        <%= f.submit (t 'defaults.list.update'), class: 'btn btn-secondary mb-4 w-40' %>
-        <%= link_to (t 'defaults.list.cancel'), wish_lists_path, class: "btn btn-accent w-40" %>
+        <%= f.submit t('defaults.list.update'), class: 'btn btn-secondary mb-4 w-40' %>
+        <%= link_to t('defaults.list.cancel'), wish_lists_path, class: "btn btn-accent w-40", data: { turbo_method: :get, turbo_confirm: t('defaults.message.cancel_confirm') } %>
       </div>
     <% end %>
   </div>

--- a/app/views/wish_lists/new.html.erb
+++ b/app/views/wish_lists/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="my-16 w-96 text-primary-content m-auto">
+<div class="my-16">
   <div class="mb-14 text-2xl text-center font-semibold">
     <h1><%= t('.title') %></h1>
   </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -37,6 +37,7 @@ ja:
       not_updated: "%{item}を更新できませんでした"
       deleted: "%{item}を削除しました"
       delete_confirm: '削除しますか？'
+      cancel_confirm: 'キャンセルしますか？'
   static_pages:
     terms_of_service:
       title: '利用規約'


### PR DESCRIPTION
## 概要

51d1824 Turboを使用しているので`status: :unprocessable_entity`を追加してエラーメッセージが表示されるように実装。
ccf5aa2 フラッシュメッセージをsuccessとerrorの2つに修正。
aa495bb エラーメッセージのテンプレート修正。
246a3cd エラーメッセージのレイアウト修正。