### PR TITLE
楽天商品検索の画像サイズと文字制限を変更

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,7 +39,7 @@ class ItemsController < ApplicationController
   end
 
   def read(result)
-    item_name = result['itemName'].truncate(30, separator: '.')
+    item_name = result['itemName'].truncate(40, separator: '.')
     item_price = result['itemPrice']
     image_url = result["mediumImageUrls"][0].sub('_ex=128x128','_ex=560x560')
     item_url = result["itemUrl"]

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,7 +41,7 @@ class ItemsController < ApplicationController
   def read(result)
     item_name = result['itemName']
     item_price = result['itemPrice']
-    image_url = result["mediumImageUrls"][0]
+    image_url = result["mediumImageUrls"][0].sub('_ex=128x128','_ex=560x560')
     item_url = result["itemUrl"]
     {
       item_name:,

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,7 +39,7 @@ class ItemsController < ApplicationController
   end
 
   def read(result)
-    item_name = result['itemName']
+    item_name = result['itemName'].truncate(30, separator: '.')
     item_price = result['itemPrice']
     image_url = result["mediumImageUrls"][0].sub('_ex=128x128','_ex=560x560')
     item_url = result["itemUrl"]

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,9 +1,9 @@
 <% @items.each do |item| %>
   <div class="card card-compact w-60 bg-base-200 rounded-3xl text-center shadow-xl m-8">
-    <%= image_tag item.image %>
     <div class="card-body">
-      <h2 class="card-title link link-hover"><%= link_to item.item_name, "#{item.url}", target: :_blank, rel: "noopener noreferrer" %></h2>
-      <p><%= number_with_delimiter(item.price) %>円</p>
+      <%= image_tag item.image, class: "pb-4" %>
+      <p class="text-xl link link-hover"><%= link_to item.item_name, "#{item.url}", target: :_blank, rel: "noopener noreferrer" %></p>
+      <p class="text-xl"><%= number_with_delimiter(item.price) %>円</p>
     </div>
     <%= form_with model: item, url: wish_list_items_path, class:"mb-4", local: true do |f| %>
       <%= f.hidden_field :item_name, :value => item.item_name %>

--- a/app/views/items/_save_items.html.erb
+++ b/app/views/items/_save_items.html.erb
@@ -1,9 +1,9 @@
 <% item.each do |item| %>
   <div class="card card-compact w-60 bg-base-200 rounded-3xl text-center shadow-xl m-8">
-    <%= image_tag item.image %>
     <div class="card-body">
-      <p class="card-title link link-hover"><%= link_to item.item_name, "#{item.url}", target: :_blank, rel: "noopener noreferrer" %></p>
-      <p><%= number_with_delimiter(item.price) %>円</p>
+      <%= image_tag item.image, class: "pb-4" %>
+      <p class="text-xl link link-hover"><%= link_to item.item_name, "#{item.url}", target: :_blank, rel: "noopener noreferrer" %></p>
+      <p class="text-xl"><%= number_with_delimiter(item.price) %>円</p>
       <div class="flex justify-evenly my-4">
         <% if current_user.own?(item) %>
           <%= button_to t('defaults.item.delete'), item_path(item), class: "btn btn-accent", method: :delete, data: { confirm: t('defaults.message.delete_confirm') } %>


### PR DESCRIPTION
## 概要
**issue** close #80 , close #81

7732ae8 `sub('_ex=128x128','_ex=560x560')`で画像サイズ変更。
dccdf23  `truncate(40, separator: '.')`で表示される文字制限。