### PR TITLE
商品画像の大きさを統一

### DIFF
--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,7 +1,7 @@
 <% @items.each do |item| %>
   <div class="card card-compact w-60 bg-base-200 rounded-3xl text-center shadow-xl m-8">
     <div class="card-body">
-      <%= image_tag item.image, class: "pb-4" %>
+      <%= image_tag item.image, class: "pb-4 object-scale-down w-52 h-52"  %>
       <p class="text-xl link link-hover"><%= link_to item.item_name, "#{item.url}", target: :_blank, rel: "noopener noreferrer" %></p>
       <p class="text-xl"><%= number_with_delimiter(item.price) %>円</p>
     </div>


### PR DESCRIPTION
## 概要
**issue** close #125

高さは統一、幅は縦横比を崩さずに調整。

2b424e1 width: 208px, height: 208px, `object-scale-down`で大きすぎる場合は縮小。
