### PR TITLE
ログインなしで他人の欲しいものリストが見れる

### DIFF
--- a/app/controllers/wish_lists_controller.rb
+++ b/app/controllers/wish_lists_controller.rb
@@ -1,5 +1,6 @@
 class WishListsController < ApplicationController
   before_action :set_wishlist, only: [:show, :edit, :update, :destroy]
+  skip_before_action :require_login, only: %i[show]
 
   def index
     @q = current_user.wish_lists.ransack(params[:q])

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -2,8 +2,8 @@
   <div class="card card-compact w-60 bg-base-200 rounded-3xl text-center shadow-xl m-8">
     <div class="card-body">
       <%= image_tag item.image, class: "pb-4 object-scale-down w-52 h-52"  %>
-      <p class="text-xl link link-hover"><%= link_to item.item_name, "#{item.url}", target: :_blank, rel: "noopener noreferrer" %></p>
-      <p class="text-xl"><%= number_with_delimiter(item.price) %>円</p>
+      <p class="font-semibold link link-hover"><%= link_to item.item_name, "#{item.url}", target: :_blank, rel: "noopener noreferrer" %></p>
+      <p class="text-xl font-semibold text-error"><%= number_with_delimiter(item.price) %>円</p>
     </div>
     <%= form_with model: item, url: wish_list_items_path, class:"mb-4", local: true do |f| %>
       <%= f.hidden_field :item_name, :value => item.item_name %>

--- a/app/views/items/_save_items.html.erb
+++ b/app/views/items/_save_items.html.erb
@@ -2,13 +2,13 @@
   <div class="card card-compact w-60 bg-base-200 rounded-3xl text-center shadow-xl m-8">
     <div class="card-body">
       <%= image_tag item.image, class: "pb-4 object-scale-down w-52 h-52" %>
-      <p class="text-xl link link-hover"><%= link_to item.item_name, "#{item.url}", target: :_blank, rel: "noopener noreferrer" %></p>
-      <p class="text-xl"><%= number_with_delimiter(item.price) %>円</p>
-      <div class="flex justify-evenly my-4">
-        <% if current_user.own?(item) %>
+      <p class="font-semibold link link-hover"><%= link_to item.item_name, "#{item.url}", target: :_blank, rel: "noopener noreferrer" %></p>
+      <p class="text-xl font-semibold text-error pt-2"><%= number_with_delimiter(item.price) %>円</p>
+      <% if current_user.own?(item) %>
+        <div class="flex justify-evenly pt-2">
           <%= button_to t('defaults.item.delete'), item_path(item), class: "btn btn-accent", method: :delete, data: { confirm: t('defaults.message.delete_confirm') } %>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -5,7 +5,7 @@
   <div class="form-control">
     <%= form_with url: new_wish_list_item_path, method: :get, local: true do |f| %>
       <div class="input-group justify-center pb-8">
-          <%= f.search_field :keyword, value: params[:keyword], class: "input input-bordered", placeholder: "Search…" %>
+          <%= f.search_field :keyword, value: params[:keyword], class: "input input-bordered w-60", placeholder: "商品名" %>
           <%= f.submit '検索', class: "btn btn-square" %>
       </div>
     <% end %>

--- a/app/views/messages/_message_list.html.erb
+++ b/app/views/messages/_message_list.html.erb
@@ -1,10 +1,10 @@
-<div class="mt-20 pb-8">
+<div class="pt-16 pb-8">
   <nav class="flex sm:flex-row justify-center">
       <%= link_to "贈ったメッセージ", sent_messages_mypage_path, class: "ext-gray-600 py-4 px-6 block hover:text-secondary-focus focus:outline-none text-secondary-focus border-b-2 font-medium border-secondary-focus" %>
       <%= link_to "貰ったメッセージ", received_messages_mypage_path, class: "text-gray-600 py-4 px-6 block hover:text-secondary-focus focus:outline-none" %>
   </nav>
-  <div class="flex flex-col-reverse w-80 m-auto mt-8">
-    <% if messages.present? %>
+  <% if messages.present? %>
+    <div class="flex flex-col-reverse w-80 m-auto pt-6">
       <% messages.each do |message| %>
         <div class="card card-compact w-80 bg-base-200 rounded-3xl text-center shadow-xl my-6 p-2 m-auto">
           <%= image_tag message.message_image.url, class:"rounded-3xl m-auto p-2", size: '300x165' %>
@@ -21,10 +21,10 @@
           </div>
         </div>
       <% end %>
-    <% else %>
-      <div class='text-center'>
-        <%= t('defaults.no_message') %>
-      </div>
-    <% end%>
-  </div>
+    </div>
+  <% else %>
+    <div class='text-center mt-8'>
+      <%= t('defaults.no_message') %>
+    </div>
+  <% end%>
 </div>

--- a/app/views/mypages/received_messages.html.erb
+++ b/app/views/mypages/received_messages.html.erb
@@ -12,17 +12,17 @@
         <%= current_user.email %>
       </div>
       <div class="pt-4">
-        <%= link_to t('defaults.edit'), edit_mypage_path, class: 'btn btn-primary btn-sm text-red-100' %>
+        <%= link_to t('defaults.edit'), edit_mypage_path, class: 'btn btn-primary text-red-100' %>
       </div>
     </div>
   </div>
-  <div class="mt-20 pb-8">
+  <div class="pt-16 pb-8">
     <nav class="flex sm:flex-row justify-center">
         <%= link_to "贈ったメッセージ", sent_messages_mypage_path, class: "text-gray-600 py-4 px-6 block hover:text-secondary-focus focus:outline-none" %>
         <%= link_to "貰ったメッセージ", received_messages_mypage_path, class: "ext-gray-600 py-4 px-6 block hover:text-secondary-focus focus:outline-none text-secondary-focus border-b-2 font-medium border-secondary-focus" %>
     </nav>
-    <div class="flex flex-col-reverse w-80 m-auto mt-8">
-      <% if @received_messages.present? %>
+    <% if @received_messages.present? %>
+      <div class="flex flex-col-reverse w-80 m-auto pt-6">
         <% @received_messages.each do |message| %>
           <div class="card card-compact w-80 bg-base-200 rounded-3xl text-center shadow-xl my-6 p-2 m-auto">
             <%= image_tag message.message_image.url, class:"rounded-3xl m-auto p-2", size: '300x165' %>
@@ -34,11 +34,11 @@
             </div>
           </div>
         <% end %>
-      <% else %>
-        <div class='text-center'>
-          <%= t('defaults.no_message') %>
-        </div>
-      <% end%>
-    </div>
+      </div>
+    <% else %>
+      <div class='text-center mt-8'>
+        <%= t('defaults.no_message') %>
+      </div>
+    <% end%>
   </div>
 </div>

--- a/app/views/mypages/sent_messages.html.erb
+++ b/app/views/mypages/sent_messages.html.erb
@@ -12,17 +12,17 @@
         <%= current_user.email %>
       </div>
       <div class="pt-4">
-        <%= link_to t('defaults.edit'), edit_mypage_path, class: 'btn btn-primary btn-sm text-red-100' %>
+        <%= link_to t('defaults.edit'), edit_mypage_path, class: 'btn btn-primary text-red-100' %>
       </div>
     </div>
   </div>
-  <div class="mt-20 pb-8">
+  <div class="pt-16 pb-8">
     <nav class="flex sm:flex-row justify-center">
         <%= link_to "贈ったメッセージ", sent_messages_mypage_path, class: "ext-gray-600 py-4 px-6 block hover:text-secondary-focus focus:outline-none text-secondary-focus border-b-2 font-medium border-secondary-focus" %>
         <%= link_to "貰ったメッセージ", received_messages_mypage_path, class: "text-gray-600 py-4 px-6 block hover:text-secondary-focus focus:outline-none" %>
     </nav>
-    <div class="flex flex-col-reverse w-80 m-auto mt-8">
-      <% if @sent_messages.present? %>
+    <% if @sent_messages.present? %>
+      <div class="flex flex-col-reverse w-80 m-auto pt-6">
         <% @sent_messages.each do |message| %>
           <div class="card card-compact w-80 bg-base-200 rounded-3xl text-center shadow-xl my-6 p-2 m-auto">
             <%= image_tag message.message_image.url, class:"rounded-3xl m-auto p-2", size: '300x165' %>
@@ -39,11 +39,11 @@
             </div>
           </div>
         <% end %>
-      <% else %>
-        <div class='text-center'>
-          <%= t('defaults.no_message') %>
-        </div>
-      <% end%>
-    </div>
+      </div>
+    <% else %>
+      <div class='text-center mt-8'>
+        <%= t('defaults.no_message') %>
+      </div>
+    <% end%>
   </div>
 </div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -13,7 +13,7 @@
         <%= current_user.email %>
       </div>
       <div class="pt-4">
-        <%= link_to t('defaults.edit'), edit_mypage_path, class: 'btn btn-primary btn-sm text-red-100' %>
+        <%= link_to t('defaults.edit'), edit_mypage_path, class: 'btn btn-primary text-red-100' %>
       </div>
     </div>
   </div>

--- a/app/views/wish_lists/_search_form.html.erb
+++ b/app/views/wish_lists/_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= search_form_for @q, url: url do |f| %>
-  <div class="input-group justify-center m-auto mb-14 w-80">
-    <%= f.search_field :list_name_cont, class: 'input input-bordered', placeholder: "リスト名" %>
+  <div class="input-group justify-center m-auto mb-14">
+    <%= f.search_field :list_name_cont, class: 'input input-bordered w-60', placeholder: "リスト名" %>
     <div class="input-group-append">
       <%= f.submit '検索', class: "btn btn-square" %>
     </div>

--- a/app/views/wish_lists/_send_message.html.erb
+++ b/app/views/wish_lists/_send_message.html.erb
@@ -1,3 +1,3 @@
 <div class="text-center mb-4">
-  <%= link_to t('defaults.message.create'), new_wish_list_message_path(@wish_list), class: "btn btn-primary text-red-100 mb-4" %>
+  <%= link_to t('defaults.message.create'), new_wish_list_message_path(@wish_list), class: "btn btn-wide btn-primary text-red-100" %>
 </div>

--- a/app/views/wish_lists/index.html.erb
+++ b/app/views/wish_lists/index.html.erb
@@ -19,7 +19,7 @@
 
   <!-- リスト作成ボタン -->
   <div class="text-center rounded-lg">
-    <%= link_to t('.create'), new_wish_list_path, class: "btn btn-primary text-red-100" %>
+    <%= link_to t('.create'), new_wish_list_path, class: "btn btn-wide btn-primary text-red-100" %>
   </div>
 
   <!-- 欲しいものリスト一覧 -->

--- a/app/views/wish_lists/show.html.erb
+++ b/app/views/wish_lists/show.html.erb
@@ -46,13 +46,14 @@
   <% end %>
 
   <!-- 商品追加ボタン or メッセージ作成ボタン -->
-  <div class="flex justify-evenly my-6">
-    <% if current_user.own?(@wish_list) %>
-      <%= link_to t('.list.add'), new_wish_list_item_path(@wish_list), class: "btn btn-wide btn-primary text-red-100" %>
-    <% else %>
-      <%= render 'send_message' %>
-    <% end %>
-  </div>
+  <% if current_user.own?(@wish_list) %>
+    <div class="flex justify-evenly my-6">
+    <%= link_to t('.list.add'), new_wish_list_item_path(@wish_list), class: "btn btn-wide btn-primary text-red-100" %>
+    </div>
+  <% else %>
+    <%= render 'send_message' %>
+  <% end %>
+
 
   <!-- リストに保存した商品一覧 -->
   <div  class="flex flex-wrap justify-evenly">


### PR DESCRIPTION
## 概要
**issue** close #113

ce58212 wish_listsのアクションshowのみrequire_loginをskip。
→ ログインなしで他人の欲しいものリストを見れるように実装。

dde1f64 マイページのメッセージ欄のデザイン修正。
2c8f5a9 楽天商品のフォントカラーやサイズを変更。
ba048ff リスト検索のwidth変更。
d5d3b41 商品検索のwidthとplaceholder変更。
5c92e87 ボタンサイズをwideに変更。
ed74d25 `<div>`の位置変更。