### PR TITLE
管理画面の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,9 @@ gem "aws-sdk-s3", require: false
 # 環境変数の設定
 gem 'dotenv-rails'
 
+# enumの多言語化対応
+gem 'enum_help'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.11.0)
     excon (0.99.0)
     factory_bot (6.2.1)
@@ -393,6 +395,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv-rails
+  enum_help
   factory_bot_rails
   fog-aws
   jbuilder

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,15 @@
+class Admin::BaseController < ApplicationController
+  before_action :check_admin
+  layout 'admin/layouts/application'
+
+  private
+
+  def not_authenticated
+    flash[:error] = t('defaults.message.require_login')
+    redirect_to admin_login_path
+  end
+
+  def check_admin
+    redirect_to root_path, error: t('defaults.message.not_authorized') unless current_user.admin?
+  end
+end

--- a/app/controllers/admin/messages_controller.rb
+++ b/app/controllers/admin/messages_controller.rb
@@ -1,0 +1,38 @@
+class Admin::MessagesController < Admin::BaseController
+  before_action :set_message, only: %i[show edit update destroy]
+
+  def index
+    @search = Message.ransack(params[:q])
+    @messages = @search.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
+  end
+
+  def show; end
+
+  def edit; end
+
+  def update
+    if @message.update(message_params)
+      image = OgpCreater.build(@message.text)
+      @message.update!(message_image: image)
+      redirect_to admin_message_path(@message), success: t('defaults.message.updated', item: Message.model_name.human)
+    else
+      flash.now[:danger] = t('defaults.message.not_updated', item: Message.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @message.destroy!
+    redirect_to admin_messages_path, success: t('defaults.message.deleted', item: Message.model_name.human)
+  end
+
+  private
+
+  def set_message
+    @message = Message.find(params[:id])
+  end
+
+  def message_params
+    params.require(:message).permit(:text, :select_item, :receiver, :sender)
+  end
+end

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -1,0 +1,22 @@
+class Admin::UserSessionsController < Admin::BaseController
+  skip_before_action :require_login, only: %i[new create]
+  skip_before_action :check_admin, only: %i[new create]
+  layout 'admin/layouts/admin_login'
+
+  def new; end
+
+  def create
+    @user = login(params[:email], params[:password])
+    if @user
+      redirect_to admin_root_path, success: t('.success')
+    else
+      flash.now[:error] = t('.fail')
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    logout
+    redirect_to admin_login_path, success: t('.success')
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,37 @@
+class Admin::UsersController < Admin::BaseController
+  before_action :set_user, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @search = User.ransack(params[:q])
+    @users = @search.result(distinct: true).order(created_at: :desc).page(params[:page])
+  end
+
+  def show; end
+
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_user_path(@user), success: t('defaults.message.updated', item: User.model_name.human)
+    else
+      flash.now[:danger] = t('defaults.message.not_updated', item: User.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @user.destroy!
+    redirect_to admin_users_path, success: t('defaults.message.deleted', item: User.model_name.human)
+  end
+
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:email, :name, :avatar, :avatar_cache, :role)
+  end
+end

--- a/app/controllers/admin/wish_lists_controller.rb
+++ b/app/controllers/admin/wish_lists_controller.rb
@@ -1,0 +1,36 @@
+class Admin::WishListsController < Admin::BaseController
+  before_action :set_wish_list, only: %i[show edit update destroy]
+
+  def index
+    @search = WishList.ransack(params[:q])
+    @wish_lists = @search.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
+  end
+
+  def show; end
+
+  def edit; end
+
+  def update
+    if @wish_list.update(wish_list_params)
+      redirect_to admin_wish_list_path(@wish_list), success: t('defaults.message.updated', item: WishList.model_name.human)
+    else
+      flash.now[:danger] = t('defaults.message.not_updated', item: WishList.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @wish_list.destroy!
+    redirect_to admin_wish_lists_path, success: t('defaults.message.deleted', item: WishList.model_name.human)
+  end
+
+  private
+
+  def set_wish_list
+    @wish_list = WishList.find(params[:id])
+  end
+
+  def wish_list_params
+    params.require(:wish_list).permit(:list_name)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,10 @@
 module ApplicationHelper
-  def page_title(page_title = '')
-    base_title = 'BESPRE'
+  def page_title(page_title = '', admin = false)
+    base_title = if admin
+                   'BESPRE(管理画面)'
+                 else
+                   'BESPRE'
+                 end
 
     page_title.empty? ? base_title : "#{page_title} | #{base_title}"
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -3,6 +3,10 @@ class Message < ApplicationRecord
   belongs_to :user
   belongs_to :wish_list
 
+  def self.ransackable_attributes(_auth_object = nil)
+    ["id", "text", "sender", "receiver", "created_at" ]
+  end
+
   validates :text, presence: true, length: { maximum: 90 }
   validates :select_item, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
   validates :name, presence: true, length: { maximum: 255 }
 
+  enum role: { general: 0, admin: 1 }
+
   def own?(object)
     id == object.user_id
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,10 @@ class User < ApplicationRecord
   has_many :items, dependent: :destroy
   has_many :messages, dependent: :destroy
 
+  def self.ransackable_attributes(_auth_object = nil)
+    ["id", "name", "email", "created_at" ]
+  end
+
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/admin/layouts/admin_login.html.erb
+++ b/app/views/admin/layouts/admin_login.html.erb
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= page_title(yield(:title), admin: true) %></title>
+    <%= display_meta_tags(default_meta_tags) %>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <link href="https://fonts.googleapis.com/css?family=Sawarabi+Mincho" rel="stylesheet">
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+  </head>
+
+  <body>
+    <div class="font-sawarabi">
+      <%= render 'shared/flash_message' %>
+      <%= yield %>
+    </div>
+  </body>
+</html>

--- a/app/views/admin/layouts/application.html.erb
+++ b/app/views/admin/layouts/application.html.erb
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= page_title(yield(:title), admin: true) %></title>
+    <%= display_meta_tags(default_meta_tags) %>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <link href="https://fonts.googleapis.com/css?family=Sawarabi+Mincho" rel="stylesheet">
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+  </head>
+
+  <body>
+    <div class="font-sawarabi">
+      <%= render 'admin/shared/header' %>
+      <%= render 'admin/shared/sidebar' %>
+      <div class="pt-20 mb-14 ml-64 mr-4">
+        <%= render 'shared/flash_message' %>
+        <div class="pt-2 pb-4">
+          <%= yield %>
+        </div>
+      </div>
+      <%= render 'admin/shared/footer' %>
+    </div>
+  </body>
+</html>

--- a/app/views/admin/messages/_message.html.erb
+++ b/app/views/admin/messages/_message.html.erb
@@ -1,0 +1,12 @@
+<tr>
+  <td><%= message.text.truncate(15, separator: '.') %></td>
+  <td><%= message.sender %></td>
+  <td><%= message.receiver %></td>
+  <td><%= message.created_at %></td>
+  <td>
+    <div class="flex text-center">
+      <%= link_to t('defaults.admin.show'), admin_message_path(message), class: "btn btn-secondary w-30 mr-4" %>
+      <%= button_to t('defaults.admin.delete'), admin_message_path(message), class: "btn btn-accent w-30", method: :delete, data: { turbo_confirm: t('defaults.message.delete_confirm') } %>
+    </div>
+  </td>
+</tr>

--- a/app/views/admin/messages/edit.html.erb
+++ b/app/views/admin/messages/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:title, t('.title')) %>
+  <div class="my-16">
+    <div class="mb-10 text-2xl text-center font-semibold">
+      <h1><%= t('.title') %></h1>
+    </div>
+    <%= form_with model: @message, url: admin_message_path, local: true do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
+      <div class="m-auto mb-4 space-y-8">
+        <div class="w-full max-w-xs m-auto">
+          <div class="mb-2">
+            <%= f.label :text %>
+          </div>
+          <%= f.text_field :text, class: 'input input-bordered bg-white w-full max-w-xs' %>
+        </div>
+        <div class="text-center">
+          <%= f.submit class: "btn btn-primary btn-sm text-red-100 my-6" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/messages/index.html.erb
+++ b/app/views/admin/messages/index.html.erb
@@ -1,0 +1,35 @@
+<% content_for(:title, t('.title')) %>
+<%= search_form_for @search, url: admin_messages_path, html: { data: { turbo_frame: "messages_list" } } do |f| %>
+  <div class="input-group  mb-4">
+    <label class="label">
+      <p class="label-text text-xl">検索条件</p>
+    </label>
+    <%= f.search_field :text, class: 'input input-bordered ml-4', placeholder: "メッセージ" %>
+    <%= f.search_field :sender, class: 'input input-bordered ml-4', placeholder: "贈った人" %>
+    <%= f.search_field :receiver, class: 'input input-bordered ml-4', placeholder: "貰った人" %>
+    <div class="input-group-append ml-4">
+      <%= f.submit '検索', class: "btn btn-square" %>
+      <%= link_to "クリア", admin_messages_path, class: "btn" %>
+    </div>
+  </div>
+<% end %>
+<div class="divider"></div>
+<%= turbo_frame_tag "messages_list" do %>
+  <div class="overflow-x-auto">
+    <table class="table w-full">
+      <thead>
+        <tr>
+          <th><%= sort_link(@search, :text) %></th>
+          <th><%= sort_link(@search, :sender) %></th>
+          <th><%= sort_link(@search, :receiver) %></th>
+          <th><%= sort_link(@search, :created_at) %></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render @messages %>
+      </tbody>
+    </table>
+    <%= paginate @messages %>
+  </div>
+<% end %>

--- a/app/views/admin/messages/show.html.erb
+++ b/app/views/admin/messages/show.html.erb
@@ -1,0 +1,26 @@
+<% content_for(:title, t('.title')) %>
+<div class="my-16">
+  <div class="mb-10 text-2xl text-center font-semibold">
+    <h1><%= t('.title') %></h1>
+  </div>
+  <div class="justify-items-center">
+    <div class="m-auto text-center space-y-8">
+      <%= image_tag @message.message_image.url, class: 'm-auto', size: '300x165' %>
+      <div class="font-semibold text-xl">
+        <%= @message.text %>
+      </div>
+      <div class="text-xl">
+        <%= @message.select_item %>
+      </div>
+      <div class="text-xl">
+        <p>贈った人【<%= @message.sender %>】</p>
+      </div>
+      <div class="text-xl">
+        <p>貰った人【<%= @message.receiver %>】</p>
+      </div>
+      <div class="pt-4">
+        <%= link_to t('defaults.admin.edit'), edit_admin_message_path, class: 'btn btn-primary text-red-100' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shared/_footer.html.erb
+++ b/app/views/admin/shared/_footer.html.erb
@@ -1,0 +1,5 @@
+<footer class="footer">
+  <div class="bg-accent-focus fixed bottom-0 left-0 right-0 p-4">
+    <p>Copyright © 2023 - All right reserved by BESPRE</p>
+  </div>
+</footer>

--- a/app/views/admin/shared/_footer.html.erb
+++ b/app/views/admin/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <div class="bg-accent-focus fixed bottom-0 left-0 right-0 p-4">
+  <div class="bg-accent-focus fixed bottom-0 left-0 right-0 p-4 z-20">
     <p>Copyright © 2023 - All right reserved by BESPRE</p>
   </div>
 </footer>

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -1,0 +1,5 @@
+<header class="fixed top-0 left-0 right-0 z-20">
+  <div class='navbar bg-accent-focus'>
+    <%= link_to image_tag('bespre_title.png'), root_path, class: 'ml-4 w-40 h-8' %>
+  </div>
+</header>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -1,0 +1,12 @@
+<div class="drawer-side fixed top-0 bottom-0 left-0 bg-base-300 pt-16">
+  <ul class="menu w-60 p-4">
+    <li class="pt-2 ml-4 text-xl"><%= current_user.name %></li>
+    <div class="divider"></div>
+    <!-- Sidebar content here -->
+    <li><%= link_to t('defaults.admin.user'), admin_users_path, class: "" %></li>
+    <li><%= link_to t('defaults.admin.wish_list'), admin_wish_lists_path, class: "" %></li>
+    <li><%= link_to t('defaults.admin.message'), admin_messages_path, class: "" %></li>
+    <div class="divider"></div>
+    <li><%= link_to t('defaults.admin.logout'), admin_logout_path, class: "" %></li>
+  </ul>
+</div>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -7,6 +7,6 @@
     <li><%= link_to t('defaults.admin.wish_list'), admin_wish_lists_path, class: "" %></li>
     <li><%= link_to t('defaults.admin.message'), admin_messages_path, class: "" %></li>
     <div class="divider"></div>
-    <li><%= link_to t('defaults.admin.logout'), admin_logout_path, class: "" %></li>
+    <li><%= button_to t('defaults.admin.logout'), admin_logout_path, class: "", method: :delete %></li>
   </ul>
 </div>

--- a/app/views/admin/user_sessions/new.html.erb
+++ b/app/views/admin/user_sessions/new.html.erb
@@ -1,0 +1,25 @@
+<% content_for(:title, t('.title')) %>
+<div class="my-16 m-auto">
+  <div class="text-2xl text-center font-semibold my-8">
+    <h1><%= t '.title' %></h1>
+  </div>
+  <%= form_with url: admin_login_path, local: true do |f| %>
+    <div class="space-y-4">
+      <div class="w-full max-w-xs m-auto">
+        <div class="mb-2">
+          <%= f.label :email, User.human_attribute_name(:email) %>
+        </div>
+        <%= f.text_field :email, class: 'input input-bordered bg-white w-full max-w-xs' %>
+      </div>
+      <div class="w-full max-w-xs m-auto">
+        <div class="mb-2">
+          <%= f.label :password, User.human_attribute_name(:password) %>
+        </div>
+        <%= f.password_field :password, class: 'input input-bordered bg-white w-full max-w-xs' %>
+      </div>
+      <div class="text-center">
+        <%= f.submit (t 'defaults.login'), class: "btn btn-primary btn-wide text-red-100 my-6" %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -1,0 +1,14 @@
+<tr>
+  <td><%= user.id %></td>
+  <td><%= image_tag user.avatar.url, class: 'rounded-full', size: '50x50' %></td>
+  <td><%= user.name %></td>
+  <td><%= user.email %></td>
+  <td><%= user.role %></td>
+  <td><%= user.created_at %></td>
+  <td>
+    <div class="flex text-center">
+      <%= link_to t('defaults.admin.show'), admin_user_path(user), class: "btn btn-secondary w-30 mr-4" %>
+      <%= button_to t('defaults.admin.delete'), admin_user_path(user), class: "btn btn-accent w-30", method: :delete, data: { turbo_confirm: t('defaults.message.delete_confirm') } %>
+    </div>
+  </td>
+</tr>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,41 @@
+<% content_for(:title, t('.title')) %>
+  <div class="my-16">
+    <div class="mb-10 text-2xl text-center font-semibold">
+      <h1><%= t('.title') %></h1>
+    </div>
+    <%= form_with model: @user, url: admin_user_path, local: true do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
+      <div class="m-auto mb-4 space-y-8">
+        <div class="text-center">
+          <%= image_tag @user.avatar.url, class: 'm-auto mb-4 rounded-full', size: '120x120' %>
+          <%= f.file_field :avatar, onchange: 'previewImage(preview)', accept: 'image/*', class: "file-input file-input-bordered file-input-primary mt-8" %>
+          <%= f.hidden_field :avatar_cache %>
+        </div>
+        <div class="w-full max-w-xs m-auto">
+          <div class="mb-2">
+            <%= f.label :name %>
+          </div>
+          <%= f.text_field :name, class: 'input input-bordered bg-white w-full max-w-xs' %>
+        </div>
+        <div class="w-full max-w-xs m-auto">
+          <div class="mb-2">
+            <%= f.label :email %>
+          </div>
+          <%= f.text_field :email, class: 'input input-bordered bg-white w-full max-w-xs' %>
+        </div>
+        <div class="w-full max-w-xs m-auto">
+          <div class="mb-2">
+            <%= f.label :role %>
+          </div>
+          <%= f.radio_button :role, :general, class: 'radio radio-primary' %>
+          <%= f.label :general %>
+          <%= f.radio_button :role, :admin, class: 'radio radio-primary' %>
+          <%= f.label :admin %>
+        </div>
+        <div class="text-center">
+          <%= f.submit class: "btn btn-primary btn-sm text-red-100 my-6" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,36 @@
+<% content_for(:title, t('.title')) %>
+<%= search_form_for @search, url: admin_users_path, html: { data: { turbo_frame: "users_list" } } do |f| %>
+  <div class="input-group  mb-4">
+    <label class="label">
+      <p class="label-text text-xl">検索条件</p>
+    </label>
+    <%= f.search_field :name_cont, class: 'input input-bordered ml-4', placeholder: "名前" %>
+    <%= f.search_field :email_cont, class: 'input input-bordered ml-4', placeholder: "メールアドレス" %>
+    <div class="input-group-append ml-4">
+      <%= f.submit '検索', class: "btn btn-square" %>
+      <%= link_to "クリア", admin_users_path, class: "btn" %>
+    </div>
+  </div>
+<% end %>
+<div class="divider"></div>
+<%= turbo_frame_tag "users_list" do %>
+  <div class="overflow-x-auto">
+    <table class="table w-full">
+      <thead>
+        <tr>
+          <th><%= sort_link(@search, :id) %></th>
+          <th>アイコン</th>
+          <th><%= sort_link(@search, :name) %></th>
+          <th><%= sort_link(@search, :email) %></th>
+          <th><%= sort_link(@search, :role) %></th>
+          <th><%= sort_link(@search, :created_at) %></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render @users %>
+      </tbody>
+    </table>
+    <%= paginate @users %>
+  </div>
+<% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,23 @@
+<% content_for(:title, t('.title')) %>
+<div class="my-16">
+  <div class="mb-10 text-2xl text-center font-semibold">
+    <h1><%= t('.title') %></h1>
+  </div>
+  <div class="justify-items-center">
+    <div class="m-auto text-center space-y-8">
+      <%= image_tag @user.avatar.url, class: 'm-auto rounded-full', size: '120x120' %>
+      <div class="font-semibold text-xl">
+        <%= @user.name %>
+      </div>
+      <div class="text-xl">
+        <%= @user.email %>
+      </div>
+      <div class="text-xl">
+        <%= @user.role %>
+      </div>
+      <div class="pt-4">
+        <%= link_to t('defaults.admin.edit'), edit_admin_user_path, class: 'btn btn-primary text-red-100' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/wish_lists/_wish_list.html.erb
+++ b/app/views/admin/wish_lists/_wish_list.html.erb
@@ -1,0 +1,12 @@
+<tr>
+  <td><%= wish_list.list_name %></td>
+  <td><%= wish_list.items.count %></td>
+  <td><%= wish_list.user.name %></td>
+  <td><%= wish_list.created_at %></td>
+  <td>
+    <div class="flex text-center">
+      <%= link_to t('defaults.admin.show'), admin_wish_list_path(wish_list), class: "btn btn-secondary w-30 mr-4" %>
+      <%= button_to t('defaults.admin.delete'), admin_wish_list_path(wish_list), class: "btn btn-accent w-30", method: :delete, data: { turbo_confirm: t('defaults.message.delete_confirm') } %>
+    </div>
+  </td>
+</tr>

--- a/app/views/admin/wish_lists/edit.html.erb
+++ b/app/views/admin/wish_lists/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:title, t('.title')) %>
+  <div class="my-16">
+    <div class="mb-10 text-2xl text-center font-semibold">
+      <h1><%= t('.title') %></h1>
+    </div>
+    <%= form_with model: @wish_list, url: admin_wish_list_path, local: true do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
+      <div class="m-auto mb-4 space-y-8">
+        <div class="w-full max-w-xs m-auto">
+          <div class="mb-2">
+            <%= f.label :list_name %>
+          </div>
+          <%= f.text_field :list_name, class: 'input input-bordered bg-white w-full max-w-xs' %>
+        </div>
+        <div class="text-center">
+          <%= f.submit class: "btn btn-primary btn-sm text-red-100 my-6" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/wish_lists/index.html.erb
+++ b/app/views/admin/wish_lists/index.html.erb
@@ -1,0 +1,33 @@
+<% content_for(:title, t('.title')) %>
+<%= search_form_for @search, url: admin_wish_lists_path, html: { data: { turbo_frame: "wish_lists" } } do |f| %>
+  <div class="input-group  mb-4">
+    <label class="label">
+      <p class="label-text text-xl">検索条件</p>
+    </label>
+    <%= f.search_field :list_name_cont, class: 'input input-bordered ml-4', placeholder: "リスト名" %>
+    <div class="input-group-append ml-4">
+      <%= f.submit '検索', class: "btn btn-square" %>
+      <%= link_to "クリア", admin_wish_lists_path, class: "btn" %>
+    </div>
+  </div>
+<% end %>
+<div class="divider"></div>
+<%= turbo_frame_tag "wish_lists" do %>
+  <div class="overflow-x-auto">
+    <table class="table w-full">
+      <thead>
+        <tr>
+          <th><%= sort_link(@search, :list_name) %></th>
+          <th>商品数</th>
+          <th>作成者</th>
+          <th><%= sort_link(@search, :created_at) %></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render @wish_lists %>
+      </tbody>
+    </table>
+    <%= paginate @wish_lists %>
+  </div>
+<% end %>

--- a/app/views/admin/wish_lists/show.html.erb
+++ b/app/views/admin/wish_lists/show.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:title, t('.title')) %>
+<div class="my-16">
+  <div class="mb-10 text-2xl text-center font-semibold">
+    <h1><%= t('.title') %></h1>
+  </div>
+  <div class="justify-items-center">
+    <div class="m-auto text-center space-y-8">
+      <div class="font-semibold text-xl">
+        <%= @wish_list.list_name %>
+      </div>
+      <div class="text-xl">
+        <%= @wish_list.user.name %>
+      </div>
+      <div class="text-xl">
+        <p>アイテム数 <%= @wish_list.items.count %></p>
+      </div>
+      <div class="pt-4">
+        <%= link_to t('defaults.admin.edit'), edit_admin_wish_list_path, class: 'btn btn-primary text-red-100' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,9 +12,17 @@ ja:
         password_confirmation: 'パスワード確認'
         name: '名前'
         avatar: 'アイコン'
+        role: '権限'
+        general: '一般ユーザー'
+        admin: '管理者'
+        created_at: '作成日'
       wish_list:
         list_name: '名前'
+        created_at: '作成日'
       message:
         select_item: 'プレゼントしたい商品'
         message_image: 'メッセージカード'
         text: 'メッセージ'
+        sender: '贈る人'
+        receiver: '貰う人'
+        created_at: '作成日'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -39,6 +39,16 @@ ja:
       deleted: "%{item}を削除しました"
       delete_confirm: '削除しますか？'
       cancel_confirm: 'キャンセルしますか？'
+    admin:
+      user: "ユーザー一覧"
+      wish_list: "欲しいものリスト一覧"
+      message: "メッセージ一覧"
+      logout: "ログアウト"
+      show: "詳細"
+      edit: "編集"
+      delete: "削除"
+      update: '更新'
+      cancel: 'キャンセル'
   static_pages:
     terms_of_service:
       title: '利用規約'
@@ -87,3 +97,33 @@ ja:
       title: 'メッセージ作成'
   terms_of_service:
     title: '利用規約'
+  admin:
+    user_sessions:
+      new:
+        title: 'ログイン'
+      create:
+        success: 'ログインしました'
+        fail: 'ログインに失敗しました'
+      destroy:
+        success: 'ログアウトしました'
+    users:
+      index:
+        title: 'ユーザー一覧'
+      edit:
+        title: 'ユーザー編集'
+      show:
+        title: 'ユーザー詳細'
+    wish_lists:
+      index:
+        title: '欲しいものリスト一覧'
+      edit:
+        title: '欲しいものリスト編集'
+      show:
+        title: '欲しいものリスト詳細'
+    messages:
+      index:
+        title: 'メッセージ一覧'
+      edit:
+        title: 'メッセージ編集'
+      show:
+        title: 'メッセージ詳細'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,14 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    root to: 'users#index'
+    get 'login', to: 'user_sessions#new'
+    post 'login', to: 'user_sessions#create'
+    delete 'logout', to: 'user_sessions#destroy'
+    resources :users, only: %i[index edit update show destroy]
+    resources :wish_lists, only: %i[index edit update show destroy]
+    resources :messages, only: %i[index show destroy]
+  end
+
   root 'static_pages#top'
   get 'terms_of_service', to: 'static_pages#terms_of_service'
   get 'privacy_policy', to: 'static_pages#privacy_policy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     delete 'logout', to: 'user_sessions#destroy'
     resources :users, only: %i[index edit update show destroy]
     resources :wish_lists, only: %i[index edit update show destroy]
-    resources :messages, only: %i[index show destroy]
+    resources :messages, only: %i[index edit update show destroy]
   end
 
   root 'static_pages#top'

--- a/db/migrate/20230311151106_add_role_to_users.rb
+++ b/db/migrate/20230311151106_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_14_160513) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_11_151106) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_160513) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "avatar"
+    t.integer "role", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## 概要
**issue** close #116

9c0b717 enumで定義した値をi18n化。
d9b9d89 ヘッダー追加。
78200da フッター追加。
68e9ac7 サイドバー追加。ユーザー一覧・欲しいものリスト一覧・メッセージ一覧・ログアウトのリンク追加。
0b89da1 adminにusersコントローラーとアクションビュー(index,show,edit)追加。
5531c38 adminにwish_listsコントローラーとアクションビュー(index,show,edit)追加。
474fdfd adminにmessagesコントローラーとアクションビュー(index,show,edit)追加。

## コメント
編集と詳細ページのレイアウトが未完成。
Turbo Framesは`<tr>`、`<td>`に対しては使えないため、Turbo Framesの導入は検討中。
→ `<table>`を`<div>`で代用するかどうか。
検索とページネーションはTurbo Frames化出来ている。