### PR TITLE
楽天の商品検索で取得するページ数の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,15 +27,16 @@ class ItemsController < ApplicationController
     @items = []
     @keyword = params[:keyword]
     if @keyword.present?
-      @results = RakutenWebService::Ichiba::Item.search(keyword: @keyword,
-                                                        page: params[:page],
-                                                        pageCount: 10,
-                                                        hits: 30,
-                                                        imageFlag: 1)
-
-      @results.each do |result|
-        item = Item.new(read(result))
-        @items << item
+      page_count = 5
+      (1..page_count).each do |page|
+        @results = RakutenWebService::Ichiba::Item.search(keyword: @keyword,
+                                                          page: page,
+                                                          hits: 30,
+                                                          imageFlag: 1)
+        @results.each do |result|
+          item = Item.new(read(result))
+          @items << item
+        end
       end
     end
     @items = Kaminari.paginate_array(@items).page(params[:page])

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 8
+  config.default_per_page = 30
   # config.max_per_page = nil
   config.window = 3
   # config.outer_window = 0


### PR DESCRIPTION
## 概要
**issue** close #73 

楽天APIの仕様では、1回のAPIリクエストで取得できる商品数が最大30件に制限されているため、それ以上の商品を取得するにはAPIリクエストを繰り返し送信する必要がありました。
繰り返し送信するために、pageCountパラメーターを使用して取得するページ数を指定し、ループ処理で各ページの商品情報を取得しました。

c60f48c 1ページあたりの表示件数を30に変更、ループ処理で各ページの商品情報を取得。

