### PR TITLE
他人のマイページが見れるように修正

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,10 +1,11 @@
 class MypagesController < ApplicationController
-  before_action :set_user, only: %i[edit update]
+  before_action :set_user, only: %i[show edit update]
+  skip_before_action :require_login, only: %i[show]
 
   def show
-    @sent_messages = Message.where(user_id: current_user.id)
-    @received_messages = Message.where(wish_list_id: current_user.wish_lists.ids)
-    @share_message = Message.find_by(wish_list_id: current_user.wish_lists.ids)
+    @sent_messages = Message.where(user_id: @user.id)
+    @received_messages = Message.where(wish_list_id: @user.wish_lists.ids)
+    @share_message = Message.find_by(wish_list_id: @user.wish_lists.ids)
   end
 
   def edit; end
@@ -21,7 +22,7 @@ class MypagesController < ApplicationController
   private
 
   def set_user
-    @user = User.find(current_user.id)
+    @user = User.find(params[:id])
   end
 
   def user_params

--- a/app/views/mypages/_tab.html.erb
+++ b/app/views/mypages/_tab.html.erb
@@ -14,7 +14,7 @@
             <p class="font-semibold text-xl"><%= message.receiver %></p>
             <p class="divider text-primary-focus text-xl">Present</p>
             <p class="font-semibold"><%= message.select_item %></p>
-            <% if current_user.own?(message) %>
+            <% if logged_in? && current_user.own?(message) %>
               <div class="flex justify-evenly pt-4">
                 <%= button_to t('defaults.item.delete'), message_path(message), class: "btn btn-accent", method: :delete, data: { confirm: t('defaults.message.delete_confirm') } %>
               </div>
@@ -39,20 +39,22 @@
             <p class="font-semibold text-xl"><%= message.sender %></p>
             <p class="divider text-primary-focus text-xl">Present</p>
             <p class="font-semibold"><%= message.select_item %></p>
-            <div class="flex justify-center pt-4">
-              <%= link_to "https://twitter.com/share?text=【#{message.sender}】さんからプレゼントメッセージが届きました！%0a%23BESPRE%0a&url=#{request.url}", target: :_blank, rel: "noopener noreferrer" do %>
-                <button class="btn btn-info mr-4">
-                  <%= image_tag "twitter.png", :size => '24x24' %>
-                  <p class="ml-4"><%= t('defaults.share') %></p>
-                </button>
-              <% end %>
-              <%= link_to "https://social-plugins.line.me/lineit/share?text=【#{message.sender}】さんからプレゼントメッセージが届きました！%0a&url=#{request.url}", target: :_blank, rel: "noopener noreferrer" do %>
-                <button class="btn btn-success">
-                  <%= image_tag "line.png", :size => '24x24' %>
-                  <p class="ml-4"><%= t('defaults.share') %></p>
-                </button>
-              <% end %>
-            </div>
+            <% if logged_in? && current_user.id == @user.id %>
+              <div class="flex justify-center pt-4">
+                <%= link_to "https://twitter.com/share?text=【#{message.sender}】さんからプレゼントメッセージが届きました！%0a%23BESPRE%0a&url=#{request.url}", target: :_blank, rel: "noopener noreferrer" do %>
+                  <button class="btn btn-info mr-4">
+                    <%= image_tag "twitter.png", :size => '24x24' %>
+                    <p class="ml-4"><%= t('defaults.share') %></p>
+                  </button>
+                <% end %>
+                <%= link_to "https://social-plugins.line.me/lineit/share?text=【#{message.sender}】さんからプレゼントメッセージが届きました！%0a&url=#{request.url}", target: :_blank, rel: "noopener noreferrer" do %>
+                  <button class="btn btn-success">
+                    <%= image_tag "line.png", :size => '24x24' %>
+                    <p class="ml-4"><%= t('defaults.share') %></p>
+                  </button>
+                <% end %>
+              </div>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,27 +1,45 @@
 <% content_for(:title, t('.title')) %>
 <% if @share_message.present? %>
   <% set_meta_tags(og: { title: "【#{@share_message.sender}】さんから届いたプレゼントメッセージです。",
-                        description: "",
+                        description: "欲しいものリストを作成してメッセージを受け取ってみよう！",
                         image: @share_message.message_image },
                         twitter: { card: 'summary_large_image' }) %>
 <% end %>
-<div class="my-16">
-  <div class="mb-10 text-2xl text-center font-semibold">
-    <h1><%= t('.title') %></h1>
-  </div>
-  <div class="justify-items-center">
-    <div class="m-auto text-center space-y-8">
-      <%= image_tag current_user.avatar.url, class: 'm-auto rounded-full', size: '120x120' %>
-      <div class="font-semibold text-xl">
-        <%= current_user.name %>
-      </div>
-      <div class="text-xl">
-        <%= current_user.email %>
-      </div>
-      <div class="pt-4">
-        <%= link_to t('defaults.edit'), edit_mypage_path, class: 'btn btn-primary text-red-100' %>
+<% if logged_in? && current_user.id == @user.id %>
+  <div class="my-16">
+    <div class="mb-10 text-2xl text-center font-semibold">
+      <h1><%= t('.title') %></h1>
+    </div>
+    <div class="justify-items-center">
+      <div class="m-auto text-center space-y-8">
+        <%= image_tag current_user.avatar.url, class: 'm-auto rounded-full', size: '120x120' %>
+        <div class="font-semibold text-xl">
+          <%= current_user.name %>
+        </div>
+        <div class="text-xl">
+          <%= current_user.email %>
+        </div>
+        <div class="pt-4">
+          <%= link_to t('defaults.edit'), edit_mypage_path, class: 'btn btn-primary text-red-100' %>
+        </div>
       </div>
     </div>
+    <%= render "tab" %>
   </div>
-  <%= render "tab" %>
-</div>
+<% else %>
+  <div class="my-16">
+    <div class="mb-10 text-2xl text-center font-semibold">
+      <h1><%= "#{@user.name}さんの" %></h1>
+      <h1><%= t('.user_profile') %></h1>
+    </div>
+    <div class="justify-items-center">
+      <div class="m-auto text-center space-y-8">
+        <%= image_tag @user.avatar.url, class: 'm-auto rounded-full', size: '120x120' %>
+        <div class="font-semibold text-xl">
+          <%= @user.name %>
+        </div>
+      </div>
+    </div>
+    <%= render "tab" %>
+  </div>
+<% end %>

--- a/app/views/shared/_bottom_navbar.html.erb
+++ b/app/views/shared/_bottom_navbar.html.erb
@@ -17,7 +17,7 @@
       <% end %>
     </li>
     <li class=" ">
-      <%= link_to mypage_path do %>
+      <%= link_to mypage_path(current_user.id) do %>
         <button class="w-20">
           <%= image_tag "mypage.png", :size => '24x24', class: "ml-7" %>
           <span class="text-sm"><%= t('defaults.mypages')  %></span>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -75,6 +75,7 @@ ja:
   mypages:
     show:
       title: 'マイページ'
+      user_profile: 'プロフィール'
     edit:
       title: 'プロフィール編集'
   password_resets:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,5 +28,5 @@ Rails.application.routes.draw do
     resources :messages, only: %i[new create destroy]
   end
 
-  resource :mypage, only: %i[show edit update]
+  resources :mypages, only: %i[show edit update]
 end


### PR DESCRIPTION
## 概要
**issue** close #118

d2e5354 マイページのリソースを単一から複数に変更
2d43e8f fd2bcc1 ボタン類の表示を条件分岐で修正
f77af4b `skip_before_action :require_login, only: %i[show]`でプロフィールはログイン前にも確認できる
