### PR TITLE
欲しいものリストをインスタント検索できるようにする

### DIFF
--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="form"
+export default class extends Controller {
+  // コントローラーに紐づく要素（=フォーム）をsubmitするアクション
+  submit() {
+    this.element.requestSubmit()
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,6 @@ application.register("preview-image", PreviewImageController)
 
 import ModalController from "./modal_controller"
 application.register("modal", ModalController)
+
+ import FormController from "./form_controller.js"
+ application.register("form", FormController)

--- a/app/views/wish_lists/_search_form.html.erb
+++ b/app/views/wish_lists/_search_form.html.erb
@@ -1,8 +1,5 @@
-<%= search_form_for @q, url: url, html: { data: { turbo_frame: "wish_list" } } do |f| %>
-  <div class="input-group justify-center m-auto mb-14">
-    <%= f.search_field :list_name_cont, class: 'input input-bordered w-60', placeholder: "リスト名" %>
-    <div class="input-group-append">
-      <%= f.submit '検索', class: "btn btn-square" %>
-    </div>
+<%= search_form_for @q, url: url, html: { data: { turbo_frame: "wish_list", controller: "form", action: "input->form#submit" } } do |f| %>
+  <div class="input text-center m-auto mb-14">
+    <%= f.search_field :list_name_cont, class: 'input input-bordered w-60', placeholder: "リスト名 検索" %>
   </div>
 <% end %>


### PR DESCRIPTION
## 概要
**issue** close #150

https://user-images.githubusercontent.com/102616360/234351688-75e8d542-7164-4e72-a4d9-a2e87a0735fe.mp4

25883e9 インスタント検索のstimulusコントローラ追加。
8d78ddf 検索バーのボタンを削除してインスタント検索に修正。